### PR TITLE
feature: type guard constructor function

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,14 +439,41 @@ const checkSomeEgg = Keys<IEgg>({
 const checkSomePickup = Or<IPickup[]>(checkSomeEgg) // missing grass
 ```
 
+### TypeGuards
+
+Since typescript type guards are an important and strong utility to narrow down types and improve strict type checking in a codebase, we provide a covienient way to turn a checker into a type guard via the `TypeGuard` constructor function.
+
+```typescript
+interface SomeObject {
+	propertyA: string
+	propertyB: boolean
+	propertyC: number
+}
+
+const checkSomeObj = Keys<SomeObject>({
+	propertyA: TypeString,
+	propertyB: TypeBoolean,
+	propertyC: TypeNumber,
+})
+
+const isSomeObject = TypeGuard(checkSomeObj)
+
+const someObj = {
+	propertyA: "allan",
+	propertyB: true,
+	propertyC: 42,
+}
+
+if (isSomeObject(someObj)) {
+	console.log("Success! " + someObj.propertyC)
+}
+```
+
 ## Roadmap / Todo
 
--   [ ] Support TypeScript 4.x
 -   [ ] JS docs annotations
 -   [ ] unit tests
--   [ ] convenient `express` integration
 -   [ ] extend common checkers
--   [ ] convenient `graphql` integration
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ const checkSomePickup = Or<IPickup[]>(checkSomeEgg) // missing grass
 
 ### TypeGuards
 
-Since typescript type guards are an important and strong utility to narrow down types and improve strict type checking in a codebase, we provide a covienient way to turn a checker into a type guard via the `TypeGuard` constructor function.
+Since typescript type guards are an important and strong utility to narrow down types and improve strict type checking in a codebase, we provide a convenient way to turn a checker into a type guard via the `TypeGuard` constructor function.
 
 ```typescript
 interface SomeObject {

--- a/src/__test__/checkers/typeguard.test.ts
+++ b/src/__test__/checkers/typeguard.test.ts
@@ -1,0 +1,51 @@
+import { Keys, TypeBoolean, TypeNumber, TypeString } from "../../common"
+import { TypeGuard } from "../../typeguard"
+
+interface SomeObject {
+	propertyA: string
+	propertyB: boolean
+}
+
+interface SomeMoreComplexObject extends SomeObject {
+	propertyC: number
+}
+
+const obj: SomeObject = {
+	propertyA: "peter",
+	propertyB: false,
+}
+const moreComplexObj: SomeMoreComplexObject = {
+	propertyA: "allan",
+	propertyB: true,
+	propertyC: 42,
+}
+const checkMoreComplexObj = Keys<SomeMoreComplexObject>({
+	propertyA: TypeString,
+	propertyB: TypeBoolean,
+	propertyC: TypeNumber,
+})
+
+test("typeguard should return true for valid input value", () => {
+	const testObj: any = moreComplexObj
+	const myGuard = TypeGuard(checkMoreComplexObj)
+
+	expect(myGuard(testObj)).toBe(true)
+})
+
+test("typeguard should return false for invalid input value", () => {
+	const testObj: any = obj
+	const myGuard = TypeGuard(checkMoreComplexObj)
+
+	expect(myGuard(testObj)).toBe(false)
+})
+
+test("typeguard should guard for valid input value", () => {
+	const testObj: any = moreComplexObj
+	const myGuard = TypeGuard(checkMoreComplexObj)
+
+	if (myGuard(testObj)) {
+		expect(testObj.propertyC).toBe(42)
+	} else {
+		throw new Error("TypeGuard failed")
+	}
+})

--- a/src/typeguard.ts
+++ b/src/typeguard.ts
@@ -1,0 +1,7 @@
+import { Checker, isCheckValid } from "./core"
+
+export const TypeGuard = <TInput, TCheck extends TInput>(checker: Checker<TInput, TCheck>) => (
+	val: TInput,
+): val is TCheck => {
+	return isCheckValid(checker(val))
+}


### PR DESCRIPTION
**Motivation:**
Checkers are great for building type guards Especially if there already are a lot of checkers for most types in a codebase, they can easily be used for building type guards.

**Changes:**
* add `TypeGuard` constructor function
* add test cases for `TypeGuard` constructor function
* add docs on `TypeGuard` constructor function
* update and cleanup todo section of readme