### PR TITLE
feature: type matches not

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ dist
 
 # local playground file
 src/playground.ts
+
+*.DS_Store

--- a/src/common.ts
+++ b/src/common.ts
@@ -83,6 +83,14 @@ export const TypeMatches = (name: string, regexp: RegExp): Checker<string, strin
 	return [null, value]
 }
 
+export const TypeMatchesNot = (name: string, regexp: RegExp): Checker<string, string> => (value) => {
+	if (regexp.test(value) === true) {
+		return [[`value does match ${name} but should not, found '${value}'`]]
+	}
+
+	return [null, value]
+}
+
 export const ConvertJSON: Checker<string, unknown> = (value) => {
 	try {
 		return [null, JSON.parse(value)]

--- a/src/common.ts
+++ b/src/common.ts
@@ -76,7 +76,7 @@ export const TypeParseBoolean: Checker<unknown, string> = (value) => {
 }
 
 export const TypeMatches = (name: string, regexp: RegExp): Checker<string, string> => (value) => {
-	if (!regexp.test(value)) {
+	if (regexp.test(value) === false) {
 		return [[`value does not match ${name}, found '${value}'`]]
 	}
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -76,7 +76,7 @@ export const TypeParseBoolean: Checker<unknown, string> = (value) => {
 }
 
 export const TypeMatches = (name: string, regexp: RegExp): Checker<string, string> => (value) => {
-	if (regexp.test(value) === false) {
+	if (!value.match(regexp)) {
 		return [[`value does not match ${name}, found '${value}'`]]
 	}
 
@@ -84,7 +84,7 @@ export const TypeMatches = (name: string, regexp: RegExp): Checker<string, strin
 }
 
 export const TypeMatchesNot = (name: string, regexp: RegExp): Checker<string, string> => (value) => {
-	if (regexp.test(value) === true) {
+	if (value.match(regexp) !== null) {
 		return [[`value does match ${name} but should not, found '${value}'`]]
 	}
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -76,7 +76,7 @@ export const TypeParseBoolean: Checker<unknown, string> = (value) => {
 }
 
 export const TypeMatches = (name: string, regexp: RegExp): Checker<string, string> => (value) => {
-	if (!value.match(regexp)) {
+	if (value.match(regexp) === null) {
 		return [[`value does not match ${name}, found '${value}'`]]
 	}
 


### PR DESCRIPTION
**Changelog:**
* add DS_Store to gitignore
* `TypeMatches` use `String.matches` instead of `RegExp.test` to mitigate issues with global flag
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
  * https://stackoverflow.com/questions/1520800/why-does-a-regexp-with-global-flag-give-wrong-results 
* add `TypeMatchesNot`